### PR TITLE
improve rollback handling

### DIFF
--- a/stdlib/nested_transactions_oracle.go
+++ b/stdlib/nested_transactions_oracle.go
@@ -15,8 +15,11 @@ func NestedTransactionsOracle(db sqlDB, tx *sql.Tx) (sqlDB, sqlTx) {
 		return &nestedTransactionOracle{Tx: tx}, tx
 
 	case *nestedTransactionOracle:
-		typedDB.Tx = tx
-		return typedDB, typedDB
+		nestedTransaction := &nestedTransactionOracle{
+			Tx:    tx,
+			depth: typedDB.depth + 1,
+		}
+		return nestedTransaction, nestedTransaction
 
 	default:
 		panic("unsupported type")
@@ -25,13 +28,12 @@ func NestedTransactionsOracle(db sqlDB, tx *sql.Tx) (sqlDB, sqlTx) {
 
 type nestedTransactionOracle struct {
 	*sql.Tx
-	atomic.Int64
+	depth int64
+	done  atomic.Bool
 }
 
 func (t *nestedTransactionOracle) BeginTx(ctx context.Context, _ *sql.TxOptions) (*sql.Tx, error) {
-	depth := t.Int64.Add(1)
-
-	if _, err := t.ExecContext(ctx, "SAVEPOINT sp_"+strconv.FormatInt(depth, 10)); err != nil {
+	if _, err := t.ExecContext(ctx, "SAVEPOINT sp_"+strconv.FormatInt(t.depth+1, 10)); err != nil {
 		return nil, fmt.Errorf("failed to create savepoint: %w", err)
 	}
 
@@ -39,14 +41,19 @@ func (t *nestedTransactionOracle) BeginTx(ctx context.Context, _ *sql.TxOptions)
 }
 
 func (t *nestedTransactionOracle) Commit() error {
-	t.Int64.Add(-1)
+	if !t.done.CompareAndSwap(false, true) {
+		return sql.ErrTxDone
+	}
+
 	return nil
 }
 
 func (t *nestedTransactionOracle) Rollback() error {
-	defer t.Int64.Add(-1)
+	if !t.done.CompareAndSwap(false, true) {
+		return sql.ErrTxDone
+	}
 
-	if _, err := t.Exec("ROLLBACK TO SAVEPOINT sp_" + strconv.FormatInt(t.Int64.Load(), 10)); err != nil {
+	if _, err := t.Exec("ROLLBACK TO SAVEPOINT sp_" + strconv.FormatInt(t.depth, 10)); err != nil {
 		return fmt.Errorf("failed to rollback to savepoint: %w", err)
 	}
 

--- a/stdlib/transactor.go
+++ b/stdlib/transactor.go
@@ -50,10 +50,12 @@ func (t *stdlibTransactor) WithinTransaction(ctx context.Context, txFunc func(co
 	}
 
 	newDB, currentTX := t.nestedTransactionsStrategy(currentDB, tx)
+	defer func() {
+		_ = currentTX.Rollback() // If rollback fails, there's nothing to do, the transaction will expire by itself
+	}()
 	txCtx := txToContext(ctx, newDB)
 
 	if err := txFunc(txCtx); err != nil {
-		_ = currentTX.Rollback() // If rollback fails, there's nothing to do, the transaction will expire by itself
 		return err
 	}
 


### PR DESCRIPTION
defer rollback, following [official recommendation](https://go.dev/doc/database/execute-transactions)
this ensures rollback is called:
- if the commit fails
- if a panic occurs after a commit, rollback is a noop