### PR TITLE
feature(stdlib): create NestedTransactionsFlattened

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The currently available strategies for nested transactions are:
 - [NestedTransactionsOracle](./stdlib/nested_transactions_oracle.go), an implementation using [Oracle savepoints](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/SAVEPOINT.html),
 - [NestedTransactionsMSSQL](./stdlib/nested_transactions_mssql.go), an implementation using [Microsoft SQL Server savepoints](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/save-transaction-transact-sql?view=sql-server-ver16),
 - [NestedTransactionsNone](./stdlib/nested_transactions_none.go), an implementation that prevents using nested transactions.
+- [NestedTransactionsFlattened](./stdlib/nested_transactions_flat.go), an implementation which allows to create nested transaction without savepoint, it allows to keep the original transaction in order to simplify the commit system. Must not be used when you want to keep intermediate sql changes.
 
 ### Use the `dbGetter` in your repositories
 

--- a/stdlib/nested_transactions_flat.go
+++ b/stdlib/nested_transactions_flat.go
@@ -1,0 +1,39 @@
+package stdlib
+
+import (
+	"context"
+	"database/sql"
+)
+
+// NestedTransactionsFlattened is a nested transactions implementation without savepoint.
+// This implementation keeps the original transaction in order to simplify the commit system,
+// this type must not be used when you want to keep intermediate sql changes.
+// It's compatible with PostgreSQL, MySQL, MariaDB, and SQLite.
+func NestedTransactionsFlattened(db sqlDB, tx *sql.Tx) (sqlDB, sqlTx) {
+	switch typedDB := db.(type) {
+	case *sql.DB:
+		return &nestedTransactionflattened{Tx: tx}, tx
+
+	case *nestedTransactionflattened:
+		return typedDB, typedDB
+
+	default:
+		panic("unsupported type")
+	}
+}
+
+type nestedTransactionflattened struct {
+	*sql.Tx
+}
+
+func (t *nestedTransactionflattened) BeginTx(ctx context.Context, _ *sql.TxOptions) (*sql.Tx, error) {
+	return t.Tx, nil
+}
+
+func (t *nestedTransactionflattened) Commit() error {
+	return nil
+}
+
+func (t *nestedTransactionflattened) Rollback() error {
+	return nil
+}


### PR DESCRIPTION
## NestedTransactionsFlattened
a nested transactions implementation without savepoint.
this implementation keeps the original transaction in order to simplify the commit system,
this type must not be used when you want to keep intermediate sql changes.
It's compatible with PostgreSQL, MySQL, MariaDB, and SQLite.