### PR TITLE
reactivate mssql tests

### DIFF
--- a/tests/sqlx/transactor_integration_test.go
+++ b/tests/sqlx/transactor_integration_test.go
@@ -1,3 +1,4 @@
+//go:debug x509negativeserial=1
 package sqlx_test
 
 import (
@@ -719,8 +720,6 @@ func TestIntegrationTransactorOracle(t *testing.T) {
 
 func TestIntegrationTransactorMSSQL(t *testing.T) {
 	t.Parallel()
-
-	t.Skip("Waiting for this issue to be fixed: https://github.com/microsoft/mssql-docker/issues/895")
 
 	ctx := context.Background()
 

--- a/tests/stdlib/transactor_integration_test.go
+++ b/tests/stdlib/transactor_integration_test.go
@@ -1,3 +1,4 @@
+//go:debug x509negativeserial=1
 package stdlib_test
 
 import (
@@ -719,8 +720,6 @@ func TestIntegrationTransactorOracle(t *testing.T) {
 
 func TestIntegrationTransactorMSSQL(t *testing.T) {
 	t.Parallel()
-
-	t.Skip("Waiting for this issue to be fixed: https://github.com/microsoft/mssql-docker/issues/895")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
The `go:debug x509negativeserial=1` fixes the certificate issue with the mssql server image See: https://github.com/microsoft/mssql-docker/issues/895